### PR TITLE
Update dependency name

### DIFF
--- a/azpay-woocommerce/azpay-woocommerce.php
+++ b/azpay-woocommerce/azpay-woocommerce.php
@@ -6,7 +6,7 @@ namespace azpay;
  * Description: Módulo de integração da AZPAY com o WooCommerce. Aceite pagamentos no seu site com cartões de crédito, boleto bancários, tranferências e aumente a sua conversão de venda.
  * Author:      AZPAY
  * Author URI:  https://www.azpay.com.br
- * Version:     1.0.1
+ * Version:     1.0.2
  * License:     GPLv2 or later
  * Text Domain: azpay-woocommerce
  * Domain Path: /languages

--- a/azpay-woocommerce/includes/views/notices/html-notice-extra-fields-missing.php
+++ b/azpay-woocommerce/includes/views/notices/html-notice-extra-fields-missing.php
@@ -17,5 +17,5 @@ if ( current_user_can( 'install_plugins' ) ) {
 ?>
 
 <div class="error">
-	<p><strong><?php _e( 'Azpay WooCommerce Disabled', 'azpay-woocommerce' ); ?></strong>: <?php printf( __( 'This plugin depends on the last version of %s to work!', 'azpay-woocommerce' ), '<a href="' . esc_url( $url ) . '">' . __( 'Extra Field Checkout For Brazil', 'azpay-woocommerce' ) . '</a>' ); ?></p>
+	<p><strong><?php _e( 'Azpay WooCommerce Disabled', 'azpay-woocommerce' ); ?></strong>: <?php printf( __( 'This plugin depends on the last version of %s to work!', 'azpay-woocommerce' ), '<a href="' . esc_url( $url ) . '">' . __( 'Brazilian Market on WooCommerce', 'azpay-woocommerce' ) . '</a>' ); ?></p>
 </div>


### PR DESCRIPTION
**Extra Field Checkout For Brazil** has a new name now:
https://br.wordpress.org/plugins/woocommerce-extra-checkout-fields-for-brazil/